### PR TITLE
Improve documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ Example input file for TALENs:
     TGGCCAATGTGACGCTGACGNNNNNNNNNNNNCTGGAGACTCCAGACTTCCA 5
     ....
 
+Cas-OFFinder can handle RNA/DNA bulges by using a small wrapper script, found
+[here](https://github.com/hyugel/cas-offinder-bulge).
+
 Installation
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ Usage
 
 Cas-OFFinder can run with:
 
-    cas-offinder {input_file} {G|C|A}[device_id(s)] {output_file}
+    cas-offinder {input_filename} {G|C|A}[device_id(s)] {output_filename|-}
 
 G stands for using GPU devices, C for using CPUs, and A for using accelerators.
 
 (Optionally, you can set device ID in addition to G/C/A to limit number of devices used by Cas-OFFinder)
+
+If the output filename is `-`, output will be written to `stdout`. This may be useful for piping to
+other commands for processing or storage.
 
 A short example may be helpful!
 


### PR DESCRIPTION
Mention writing to `stdout`, and handling RNA/DNA bulges via a wrapper script (as is done by the online version).