### PR TITLE
Allow stdin for input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# cmake and make generated files
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cas-offinder
+cmake_install.cmake
+config.h
+oclkernels.h

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Usage
 
 Cas-OFFinder can run with:
 
-    cas-offinder {input_filename} {G|C|A}[device_id(s)] {output_filename|-}
+    cas-offinder {input_filename|-} {G|C|A}[device_id(s)] {output_filename|-}
 
 G stands for using GPU devices, C for using CPUs, and A for using accelerators.
 
 (Optionally, you can set device ID in addition to G/C/A to limit number of devices used by Cas-OFFinder)
 
-If the output filename is `-`, output will be written to `stdout`. This may be useful for piping to
-other commands for processing or storage.
+The special filename `-` may be used in place of the input and output filename to read and write
+from `stdin` and `stdout`, respectively.
 
 A short example may be helpful!
 

--- a/cas-offinder.cpp
+++ b/cas-offinder.cpp
@@ -430,29 +430,26 @@ void Cas_OFFinder::print_usage() {
 	}
 }
 
-void Cas_OFFinder::readInputFile(const char* inputfile) {
-	unsigned int dev_index;
-	string pattern, line;
+void Cas_OFFinder::parseInput(istream& input) {
+	string line;
 	vector<string> sline;
-	cl_uint zero = 0;
 
-	ifstream fi(inputfile, ios::in);
-	if (!fi.good()) {
+	if (!input.good()) {
 		exit(0);
 	}
 
-	if (!fi.eof())
-		getline(fi, chrdir);
+	if (!input.eof())
+		getline(input, chrdir);
 	if (chrdir[chrdir.length()-1] == '\r')
 		chrdir = chrdir.substr(0, chrdir.length()-1);
 
-	if (!fi.eof())
-		getline(fi, pattern);
-	if (pattern[pattern.length()-1] == '\r')
-		pattern = pattern.substr(0, pattern.length()-1);
+	if (!input.eof())
+		getline(input, m_pattern);
+	if (m_pattern[m_pattern.length()-1] == '\r')
+		m_pattern = m_pattern.substr(0, m_pattern.length()-1);
+	transform(m_pattern.begin(), m_pattern.end(), m_pattern.begin(), ::toupper);
 
-	transform(pattern.begin(), pattern.end(), pattern.begin(), ::toupper);
-	while (getline(fi, line)) {
+	while (getline(input, line)) {
 		if (line.empty()) break;
 		if (line[line.length()-1] == '\r')
 			line = line.substr(0, line.length()-1);
@@ -461,14 +458,26 @@ void Cas_OFFinder::readInputFile(const char* inputfile) {
 		m_compares.push_back(sline[0]);
 		m_thresholds.push_back(atoi(sline[1].c_str()));
 	}
-	fi.close();
+}
+
+void Cas_OFFinder::readInputFile(const char* inputfile) {
+	unsigned int dev_index;
+	cl_uint zero = 0;
+
+	if (strlen(inputfile) == 1 && inputfile[0] == '-') {
+		parseInput(cin);
+	} else {
+		ifstream fi(inputfile, ios::in);
+		parseInput(fi);
+		fi.close();
+	}
 
 	m_totalcompcount = m_thresholds.size();
-	m_patternlen = (cl_uint)(pattern.size());
+	m_patternlen = (cl_uint)(m_pattern.size());
 	
-	cl_char *cl_pattern = new cl_char[m_patternlen * 2]; 
-	memcpy(cl_pattern, pattern.c_str(), m_patternlen);
-	memcpy(cl_pattern + m_patternlen, pattern.c_str(), m_patternlen);
+	cl_char *cl_pattern = new cl_char[m_patternlen * 2];
+	memcpy(cl_pattern, m_pattern.c_str(), m_patternlen);
+	memcpy(cl_pattern + m_patternlen, m_pattern.c_str(), m_patternlen);
 	set_complementary_sequence(cl_pattern+m_patternlen, m_patternlen);
 	cl_int *cl_pattern_flags = new cl_int[m_patternlen * 2];
 	set_seq_flags(cl_pattern_flags, cl_pattern, m_patternlen);

--- a/cas-offinder.h
+++ b/cas-offinder.h
@@ -36,6 +36,7 @@ private:
 	vector<cl_ushort> m_thresholds;
 	vector<unsigned long long> m_chrpos;
 	string m_chrdata;
+	string m_pattern;
 
 	cl_uint m_threshold;
 	cl_uint m_patternlen;
@@ -80,6 +81,7 @@ private:
 	void set_complementary_sequence(cl_char* seq, size_t seqlen);
 	void set_seq_flags(int* seq_flags, const cl_char* seq, size_t seqlen);
 	void initOpenCL(vector<int> dev_ids);
+	void parseInput(istream& input);
 
 public:
 	vector<string> chrnames;

--- a/cas-offinder.h
+++ b/cas-offinder.h
@@ -36,7 +36,6 @@ private:
 	vector<cl_ushort> m_thresholds;
 	vector<unsigned long long> m_chrpos;
 	string m_chrdata;
-	cl_char* m_pattern;
 
 	cl_uint m_threshold;
 	cl_uint m_patternlen;


### PR DESCRIPTION
Allow `-` to be use to read the input from `stdin`, as can be done with the output.

My use case is to invoke `cas-offinder` without creating a temporary file for the input.  For example,

```python
from subprocess import run, PIPE

genes = "/data/genomes"
pattern = "NNNNNNNNNNNNNNNNNNNNNRG"
guide = "TCGCCAGGGGCCCCCAAGAAAGG"
mismatches = 2
device = 'C0'

cas_offinder_input = '\n'.join([genes, pattern, ' '.join([guide, str(mismatches)])])

cas_offinder = run(['./cas-offinder', '-', device, '-'],
                   input=cas_offinder_input,
                   stdout=PIPE,
                   stderr=PIPE,
                   encoding='ASCII')

fields = ['query_sequence', 'chromosome', 'position', 'matched_sequence', 'direction', 'mismatches']
matches = [dict(zip(fields, match.split('\t'))) for match in cas_offinder.stdout.strip().split('\n')]
```