### PR TITLE
Allow use of the OpenCL 1.2 API without deprecation warning

### DIFF
--- a/cas-offinder.h
+++ b/cas-offinder.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <algorithm>
 
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #ifdef __APPLE__
 #  include <OpenCL/cl.h>
 #else


### PR DESCRIPTION
Eliminate a compiler deprecation warning by permitting use of the pre-2.0 API.  This can be removed if cas-offinder is updated to only support OpenCL 2 devices.