### PR TITLE
Follow FASTA file symlinks

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
 		}
 	} else {
 		while ((ent = readdir(dir)) != NULL) {
-			if (ent->d_type == DT_REG) {
+			if (ent->d_type == DT_REG || ent->d_type == DT_LNK) {
 				filepath = s.chrdir + "/" + ent->d_name;
 				run_cas_offinder(s, filepath.c_str(), outfilename.c_str(), &cnum);
 			}

--- a/main.cpp
+++ b/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 		error_exit(2, "Unknown option: ", argv[2]);
 	}
 
-    string devarg = argv[2]+1;
+	string devarg = argv[2]+1;
 	Cas_OFFinder s(devtype, devarg);
 
 	cerr << "Loading input file..." << endl;


### PR DESCRIPTION
Allow Cas-OFFinder to follow symlinks to FASTA files.

Currently, Cas-OFFinder will not search `foo.fa` if it is a symlink:

`path/to/chromosomes/foo.fa -> ../path/to/elsewhere/other.fa`