### PR TITLE
Simple sanity check to avoid segfault on array out-of-bounds access

### DIFF
--- a/cas-offinder.cpp
+++ b/cas-offinder.cpp
@@ -454,6 +454,10 @@ void Cas_OFFinder::parseInput(istream& input) {
 		if (line[line.length()-1] == '\r')
 			line = line.substr(0, line.length()-1);
 		sline = split(line);
+		if (sline.size() != 2) {
+			cout << "Skipping malformed input guide line." << endl;
+			break;
+		}
 		transform(sline[0].begin(), sline[0].end(), sline[0].begin(), ::toupper);
 		m_compares.push_back(sline[0]);
 		m_thresholds.push_back(atoi(sline[1].c_str()));


### PR DESCRIPTION
If the guide input lines are malformed (i.e., without a number of tolerated mismatches), cas-offinder will segfault when [`.atoi()` is called](https://github.com/richardkmichael/cas-offinder/blob/master/cas-offinder.cpp#L459).

Bad input, no mismatches on line 3:

```
foo.fa
NNNNNNNNNNNNNNNNNNNNNRG
CTTTCCCCGGCACTGGCTGGGAG
```

```
foo.fa
NNNNNNNNNNNNNNNNNNNNNRG
CTTTCCCCGGCACTGGCTGGGAG 0
```

