### PR TITLE
fix offset bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Install APT packages
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y cmake opencl-headers ocl-icd-opencl-dev
+        run: sudo apt-get update -y; sudo apt-get install -y cmake opencl-headers ocl-icd-opencl-dev
       - name: Create Build Environment
         run: mkdir build
       - name: Build (Linux/macOS)

--- a/cas-offinder.cpp
+++ b/cas-offinder.cpp
@@ -113,7 +113,7 @@ void Cas_OFFinder::initOpenCLDevices(vector<unsigned int> dev_ids) {
 		m_contexts.push_back(context);
 		program = oclCreateProgramWithSource(context, 1, &program_src, &src_len);
 		oclBuildProgram(program, 1, &devices[i], "", 0, 0);
-        if (m_devtype == CL_DEVICE_TYPE_CPU) {
+				if (m_devtype == CL_DEVICE_TYPE_CPU) {
 		m_finderkernels.push_back(oclCreateKernel(program, "finder_cpu"));
 		m_comparerkernels.push_back(oclCreateKernel(program, "comparer_cpu"));
 	} else {
@@ -404,7 +404,11 @@ void Cas_OFFinder::compareAll(const char* outfilename, bool issummary) {
 									is_reversed_pam = true;
 									bulge_index = -bi.second;
 								} else {
-									is_reversed_pam = false;
+									if (m_directions[dev_index][i] == '-') {
+										is_reversed_pam = true;
+									} else {
+										is_reversed_pam = false;
+									}
 									bulge_index = bi.second;
 								}
 								if (isnumeric(bi.first)) {
@@ -479,7 +483,7 @@ void Cas_OFFinder::writeSummaryTable(const char* summaryfilename) {
 		fo = new ofstream(summaryfilename, ios::out);
 		isfile = true;
 	}
-    for (const auto& kv : m_summarytable) {
+		for (const auto& kv : m_summarytable) {
 		cnt = 0;
 		key = string(kv.first);
 		(*fo) << "##";
@@ -489,8 +493,8 @@ void Cas_OFFinder::writeSummaryTable(const char* summaryfilename) {
 			key.erase(0, pos + 1);
 		}
 		(*fo) << summaryheaders[cnt++] << "=" << key << ";";
-        (*fo) << "Number of Found Targets=" << kv.second << endl;
-    }
+				(*fo) << "Number of Found Targets=" << kv.second << endl;
+		}
 	if (isfile)
 		((ofstream *)fo)->close();
 }
@@ -525,7 +529,7 @@ void Cas_OFFinder::print_usage() {
 		"(C: using CPUs, G: using GPUs, A: using accelerators)" << endl
 		<< endl <<
 		"Options" << endl <<
-		"  --summary <file>        Print summary table to the specified file." << endl
+		"  --summary <file>				 Print summary table to the specified file." << endl
 		<< endl <<
 		"Example input file (DNA bulge 2, RNA bulge 1):" << endl <<
 		"/var/chromosomes/human_grch38" << endl <<


### PR DESCRIPTION
Here’s an overview of the fixes
In cases when the query pattern has a forward PAM, yet there is a match with a
section of the chromosome in the reverse direction, an offset is mistakenly
added when reporting the location of the matched chromosome section.
An example input file:
```
/var/hg38_chr11
NNNNNNNNNNNNNNNNNNNNNRG 1 0
TTTGTGGTTAAGGAAAGCGGNRG 1
```
The incorrect output:
```
##Generated by Cas-OFFinder 3.0.0
#Id	Bulge Type	crRNA	DNA	Chromosome	Location	Direction	Mismatches	Bulge Size
0	X	TTTGTGGTTAAGGAAAGCGGNRG	TTTGTGGTTAAGGAAAGCGGCGG	chr11	17719597	-	0	0
```
The reported location is 17719597. An offset of 1 is added to the correct value
of 17719596, which would be appropriate of the matched locus was forward sense.
The corrected output using these changes:
```
##Generated by Cas-OFFinder 3.0.0
#Id	Bulge Type	crRNA	DNA	Chromosome	Location	Direction	Mismatches	Bulge Size
0	X	TTTGTGGTTAAGGAAAGCGGNRG	TTTGTGGTTAAGGAAAGCGGCGG	chr11	17719596	-	0	0
```